### PR TITLE
Add link to 8icons

### DIFF
--- a/cypress/e2e/settings.cy.ts
+++ b/cypress/e2e/settings.cy.ts
@@ -1,0 +1,13 @@
+const icons8Link = "https://icons8.com"
+describe("the settings page", () => {
+  beforeEach(() => {
+    cy.login()
+    cy.visit("/settings")
+  })
+
+  it("should somewhere contain a link to Icons8", function () {
+    cy.get("a[href]").each(($el) => {
+      cy.wrap($el.attr("href")).should("include", icons8Link)
+    })
+  })
+})

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -5,6 +5,12 @@ export default function Settings() {
     <div className={"page-wrapper lg:w-3/5"}>
       <h1 className={"page-header lg:text-center"}>Settings</h1>
       <NotificationSettings />
+      <p className={"bottom-0 pt-6 text-center italic text-zinc-300"}>
+        Icons by{" "}
+        <a href={"https://icons8.com"} className={"underline"}>
+          Icons8
+        </a>
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
To use the instrument icons from icons8 for free we need to link to them. [source: https://icons8.com/license]
This PR will do that and also add a test to make sure that the settings page contains a link to it. 

* Closes #108 