### PR TITLE
Change e2e tests to temp component tests for faster testing

### DIFF
--- a/cypress/e2e/new-suggestion/helpers/new-suggestion.helper.ts
+++ b/cypress/e2e/new-suggestion/helpers/new-suggestion.helper.ts
@@ -41,6 +41,15 @@ export const newSuggestionFilledSongInformation: NewSuggestion = {
   instruments: [],
 }
 
+export const newSuggestionFilledInInstruments: NewSuggestion = {
+  artist: ["The Beatles"],
+  link: "www.hello.com",
+  motivation:
+    "We have already sung it once while just playing randomly and it was pretty fun so thought it would be nice to add it to the repertoire.",
+  title: "Let It Be",
+  instruments: [filledInInstrument],
+}
+
 export const shouldGoToInstrumentsArea = () => {
   cy.data(buttonAddInstruments).click()
   cy.data(areaInstruments).should("be.visible")

--- a/cypress/e2e/new-suggestion/new-suggestion-instruments.cy.ts
+++ b/cypress/e2e/new-suggestion/new-suggestion-instruments.cy.ts
@@ -48,7 +48,7 @@ describe("when creating a new suggestion, adding instruments", () => {
           .invoke("dispatch", updateNewSuggestion(newSuggestionFilledSongInformation))
       },
     })
-
+    cy.wait(500) // Wait so content can render properly and set up submit events
     cy.data(progressBarInstruments).click()
   })
 

--- a/cypress/e2e/new-suggestion/new-suggestion-instruments.cy.ts
+++ b/cypress/e2e/new-suggestion/new-suggestion-instruments.cy.ts
@@ -5,7 +5,10 @@ import {
   addInstrumentItem,
   shouldGoToReviewArea,
   shouldBeFilledState,
+  newSuggestionFilledSongInformation,
 } from "./helpers/new-suggestion.helper"
+import { CyHttpMessages } from "cypress/types/net-stubbing"
+import { updateNewSuggestion } from "@/redux/slices/new-suggestion.slice"
 
 const toReviewButton = "to-review-button"
 const searchInstrumentInput = "search-instrument-input"
@@ -14,15 +17,39 @@ const instrumentEditList = "instrument-edit-list"
 const deleteButton = "delete-button"
 const instrumentSearchCloseButton = "instrument-search-close-button"
 const descriptionInput = "description-input"
+const progressBarInstruments = "new-suggestion-progress-bar-instruments"
+
+let instrumentResponseCache: CyHttpMessages.BaseMessage
 
 describe("when creating a new suggestion, adding instruments", () => {
-  beforeEach(() => {
+  before(() => {
     cy.login()
     cy.visit("/suggestions/new")
-    // Wait so content can render properly and set up submit events
-    cy.wait(500)
-    fillSongInformationSuccessfully()
-    shouldGoToInstrumentsArea()
+
+    //Intercept and cache the instrument list
+    cy.intercept("GET", "/rest/v1/instrument?select=*&order=instrument_name.asc").as(
+      "getInstruments"
+    )
+    cy.wait("@getInstruments").then((intercept) => {
+      instrumentResponseCache = intercept.response
+    })
+  })
+
+  beforeEach(() => {
+    cy.login()
+    cy.intercept("GET", "/rest/v1/instrument?select=*&order=instrument_name.asc", {
+      body: instrumentResponseCache.body,
+    })
+
+    cy.visit("/suggestions/new", {
+      onBeforeLoad(win: Cypress.AUTWindow) {
+        cy.window()
+          .its("store")
+          .invoke("dispatch", updateNewSuggestion(newSuggestionFilledSongInformation))
+      },
+    })
+
+    cy.data(progressBarInstruments).click()
   })
 
   it("should error if it can't retrieve instruments", () => {

--- a/cypress/e2e/new-suggestion/new-suggestion-review.cy.ts
+++ b/cypress/e2e/new-suggestion/new-suggestion-review.cy.ts
@@ -1,19 +1,20 @@
 import { NewSuggestion } from "@/interfaces/new-suggestion"
-import {
-  fillSongInformationSuccessfully,
-  shouldGoToInstrumentsArea,
-  fillInstrumentsSuccessfully,
-  shouldGoToReviewArea,
-} from "./helpers/new-suggestion.helper"
+import { newSuggestionFilledInInstruments } from "./helpers/new-suggestion.helper"
+import { updateNewSuggestion } from "@/redux/slices/new-suggestion.slice"
+const progressBarReview = "new-suggestion-progress-bar-review"
 
 const setUp = () => {
   cy.login()
-  cy.visit(`/suggestions/new`)
+  cy.visit("/suggestions/new", {
+    onBeforeLoad(win: Cypress.AUTWindow) {
+      cy.window()
+        .its("store")
+        .invoke("dispatch", updateNewSuggestion(newSuggestionFilledInInstruments))
+    },
+  })
+
   cy.wait(500) // Wait so content can render properly and set up submit events
-  fillSongInformationSuccessfully()
-  shouldGoToInstrumentsArea()
-  fillInstrumentsSuccessfully()
-  shouldGoToReviewArea()
+  cy.data(progressBarReview).click()
 }
 
 describe("review new suggestion page", () => {


### PR DESCRIPTION
-	Reduces testing time by skipping user steps
-  Caches instrument list before each new-suggestion-instrument test for re-use during test.