### PR TITLE
Only use build & test node version 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,16 +29,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: dev
-    strategy:
-      matrix:
-        node-version: [ 16.x, 18.x ]
     # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           cache: 'npm'
       - name: Clean install node modules
         run: npm ci


### PR DESCRIPTION
Node.js 14 and 16 are being deprecated in Vercel
https://vercel.com/changelog/node-js-14-and-16-are-being-deprecated