### PR TITLE
Hotfix/suggestion create and edit

### DIFF
--- a/src/components/images/preview-player.tsx
+++ b/src/components/images/preview-player.tsx
@@ -9,7 +9,7 @@ export interface PreviewPlayerProps {
 }
 
 const PreviewPlayer = ({ url, color }: PreviewPlayerProps) => {
-  const [audio, setAudio] = useState<any>()
+  const [audio, setAudio] = useState<HTMLAudioElement>()
   const [playing, setPlaying] = useState(false)
 
   const router = useRouter()

--- a/src/components/suggestion/areas/review.area.tsx
+++ b/src/components/suggestion/areas/review.area.tsx
@@ -8,7 +8,6 @@ import SongPreviewImage from "@/components/images/song-preview-image"
 
 interface ReviewAreaProps {
   newSuggestion: ISuggestion
-
   onSubmit(onSuccess: () => void, onError: () => void): void
 }
 

--- a/src/components/suggestion/areas/review.area.tsx
+++ b/src/components/suggestion/areas/review.area.tsx
@@ -4,10 +4,11 @@ import ErrorPopup from "@/components/popups/error-popup"
 import Instrument from "@/components/suggestion/instrument"
 import { ISuggestion } from "@/interfaces/suggestion"
 import SuggestionLink from "@/components/suggestion/song-information/suggestion-link"
-import SongImage from "@/components/images/song-image"
+import SongPreviewImage from "@/components/images/song-preview-image"
 
 interface ReviewAreaProps {
   newSuggestion: ISuggestion
+
   onSubmit(onSuccess: () => void, onError: () => void): void
 }
 
@@ -47,7 +48,7 @@ const ReviewArea = ({ newSuggestion: suggestion, onSubmit }: ReviewAreaProps) =>
         <>
           <div className={"m-2 text-left md:ml-auto md:mr-auto md:max-w-sm"}>
             <div className={"flex"}>
-              <SongImage url={suggestion.image}/>
+              <SongPreviewImage previewUrl={suggestion.previewUrl} imageUrl={suggestion.image} />
               <div className={"ml-3"}>
                 <span data-cy="review-title">
                   <p className={"line-clamp-1 font-bold"}>{suggestion.title}</p>

--- a/src/components/suggestion/areas/song-information.area.tsx
+++ b/src/components/suggestion/areas/song-information.area.tsx
@@ -63,10 +63,8 @@ const SongInformationArea = ({ proceedToNextArea, onFormSuccess }: SongInformati
   }
 
   const debouncedHandleSearch = debounce((value: string) => {
-    if (value.length == 0) return
-
     setFetchingSongs(true)
-    getSpotifySearchResults(basePath, getValues().title)
+    getSpotifySearchResults(basePath, value)
       .then(async (response) => {
         const data: SpotifySearchItem[] = (await response.json()).tracks.items
         const items: SearchItem[] = data.map((item) => ({
@@ -84,6 +82,7 @@ const SongInformationArea = ({ proceedToNextArea, onFormSuccess }: SongInformati
   }, 400)
 
   const handleSearch = (value: string) => {
+    if (manualInput || value.trim().length < 1) return
     setValue("title", value)
     debouncedHandleSearch(value)
   }
@@ -124,58 +123,41 @@ const SongInformationArea = ({ proceedToNextArea, onFormSuccess }: SongInformati
             />
           )}
 
-          {manualInput ? (
-            <div className="input">
-              <input
-                data-cy={"input-title"}
-                type="text"
-                placeholder="Title"
-                className={`${errors.title && "error"}`}
-                {...register("title", {
-                  validate: (value) => !!value.trim()
-                })}
-              />
-              <span>
-                <DocumentTextIcon />
-              </span>
-            </div>
-          ) : (
-            <div className="input">
-              <input
-                data-cy={"input-title"}
-                type="text"
-                placeholder="Search for a song title"
-                className={`${errors.title && "error"}`}
-                {...register("title", {
-                  validate: (value) => !!value.trim(),
-                  onChange: (event) => handleSearch(event.target.value)
-                })}
-                onFocus={() => setIsSearchFocused(true)}
-                onBlur={handleSearchBlur}
-              />
-              <span>{fetchingSongs ? <Spinner size={2} /> : <DocumentTextIcon />}</span>
-              {isSearchFocused && getValues().title.length !== 0 && searchResults.length > 0 && (
-                <div className="absolute z-10 w-full rounded-md bg-white shadow-md outline outline-1 outline-gray-300">
-                  <ul data-cy="song-information-dropdown">
-                    {searchResults.map((item: SearchItem) => {
-                      return (
-                        <div
-                          key={item.id}
-                          onClick={() => onSelectSearchResult(item)}
-                          className={
-                            "cursor-pointer items-center p-4 hover:bg-moon-300 hover:text-white"
-                          }
-                        >
-                          <b>{item.title}</b>
-                          <p>{item.artists.join(", ")}</p>
-                        </div>
-                      )
-                    })}
-                  </ul>
-                </div>
-              )}
-            </div>
-          )}
+          <div className="input">
+            <input
+              data-cy={"input-title"}
+              type="text"
+              placeholder="Search for a song title"
+              className={`${errors.title && "error"}`}
+              {...register("title", {
+                validate: (value) => !!value.trim(),
+                onChange: (event) => handleSearch(event.target.value)
+              })}
+              onFocus={() => setIsSearchFocused(true)}
+              onBlur={handleSearchBlur}
+            />
+            <span>{fetchingSongs ? <Spinner size={2} /> : <DocumentTextIcon />}</span>
+            {isSearchFocused && getValues().title.length !== 0 && searchResults.length > 0 && (
+              <div className="absolute z-10 w-full rounded-md bg-white shadow-md outline outline-1 outline-gray-300">
+                <ul data-cy="song-information-dropdown">
+                  {searchResults.map((item: SearchItem) => {
+                    return (
+                      <div
+                        key={item.id}
+                        onClick={() => onSelectSearchResult(item)}
+                        className={
+                          "cursor-pointer items-center p-4 hover:bg-moon-300 hover:text-white"
+                        }
+                      >
+                        <b>{item.title}</b>
+                        <p>{item.artists.join(", ")}</p>
+                      </div>
+                    )
+                  })}
+                </ul>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className={`input-container`} hidden={!manualInput}>

--- a/src/pages/suggestions/edit/[suggestion].tsx
+++ b/src/pages/suggestions/edit/[suggestion].tsx
@@ -161,14 +161,16 @@ const EditSuggestionPage = ({ suggestion }: EditSuggestionPageProps) => {
     dispatch(setActiveArea(Area.Review))
   }
 
-  const onSongInformationSubmit = ({ title, artist, link, motivation }: InputsSongInformation) => {
+  const onSongInformationSubmit = ({ title, artist, link, motivation, image, previewUrl }: InputsSongInformation) => {
     dispatch(
       updateEditSuggestion({
         ...reduxSuggestion,
         title,
         artist: [artist],
         link,
-        motivation
+        motivation,
+        image,
+        previewUrl
       })
     )
   }

--- a/src/services/suggestion.service.ts
+++ b/src/services/suggestion.service.ts
@@ -99,7 +99,7 @@ export const insertSuggestion = async (
 
 export const updateSuggestion = async (
   supabaseClient: SupabaseClient<Database>,
-  { artist, link, motivation, title }: ISuggestion,
+  { artist, link, motivation, title, image, previewUrl }: ISuggestion,
   uid: string
 ) => {
   return supabaseClient
@@ -108,7 +108,9 @@ export const updateSuggestion = async (
       title: title,
       artist: artist,
       motivation: motivation,
-      link: link
+      link: link,
+      image: image,
+      previewUrl: previewUrl
     })
     .eq("id", uid)
     .select()


### PR DESCRIPTION
Just some minor fixes:
- implemented right type for audio from the preview player
- implemented the preview player instead of the song image component in the review area
- get the accurate value when searching for a Spotify song
- simplified the manual/auto-fill logic for the title field
- implemented the easier approach for validating if the user has the admin scope for suggestions (got removed with a merge probably?)
-  also update image and preview url on update