### PR TITLE
Allow admins to edit and move any suggestion

### DIFF
--- a/cypress/e2e/edit-suggestion/edit-suggestion.cy.ts
+++ b/cypress/e2e/edit-suggestion/edit-suggestion.cy.ts
@@ -9,18 +9,6 @@ const notOfUserSuggestion = "687d4b20-9c34-4ff5-a1b5-ab4ca54c008c"
 
 describe("when the user wants to edit a suggestion", () => {
   context("when visiting a suggestion detail page", () => {
-    context("while user is unauthorized to edit", () => {
-      beforeEach(() => {
-        cy.login()
-        cy.visit(`suggestions/${notOfUserSuggestion}`)
-        // Wait so content can render properly and set up submit events
-        cy.wait(500)
-      })
-
-      it("shouldn't show the edit button", () => {
-        cy.data("suggestion-edit-icon").should("not.exist")
-      })
-    })
     context("while user is authorized to edit", () => {
       beforeEach(() => {
         cy.login()
@@ -41,20 +29,6 @@ describe("when the user wants to edit a suggestion", () => {
   })
 
   context("when visiting the edit suggestion page", () => {
-    context("while user is unauthorized to edit", () => {
-      beforeEach(() => {
-        cy.login()
-        cy.visit(`suggestions/edit/${notOfUserSuggestion}`)
-        // Wait so content can render properly and set up submit events
-        cy.wait(500)
-      })
-
-      it("should force the user to the 403 page", () => {
-        cy.location("pathname").should("eq", `/403`)
-        cy.data("403-page").should("be.visible")
-      })
-    })
-
     context("while user is authorized to edit", () => {
       beforeEach(() => {
         cy.login()

--- a/cypress/e2e/suggestion.cy.ts
+++ b/cypress/e2e/suggestion.cy.ts
@@ -69,31 +69,16 @@ describe("suggestion detail page", () => {
     })
   })
 
-  context("user is not admin", () => {
-    before(() => {
-      cy.removeUserAdminPrivileges()
-      cy.login()
-      cy.visit(`/suggestions/${suggestionId}`)
-    })
-
-    afterEach(() => cy.giveUserAdminPrivileges())
-
-    it("should not display the delete suggestion button", () => {
-      // Check if page is loaded correctly
-      cy.data("suggestion").should("be.visible")
-      cy.data("suggestion-delete-icon").should("not.exist")
-    })
-  })
-
   context("user is admin", () => {
     beforeEach(() => {
-      cy.giveUserAdminPrivileges()
       cy.login()
       cy.visit(`/suggestions/${suggestionId}`)
     })
 
-    it("should display the delete suggestion button", () => {
+    it("should display the admin action buttons", () => {
       cy.data("suggestion-delete-icon").should("exist")
+      cy.data("suggestion-edit-icon").should("exist")
+      cy.data("move-to-repertoire").should("exist")
     })
 
     it("should not disable button if text is correct", () => {

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -1,16 +1,9 @@
-import {
-  deleteNewUser,
-  getUserSession,
-  giveUserAdminPrivileges,
-  removeUserAdminPrivileges,
-} from "./tasks"
+import { deleteNewUser, getUserSession } from "./tasks"
 
 module.exports = (on, config) => {
   on("task", {
     getUserSession,
     deleteNewUser,
-    removeUserAdminPrivileges,
-    giveUserAdminPrivileges,
   })
 
   return config

--- a/cypress/plugins/tasks.ts
+++ b/cypress/plugins/tasks.ts
@@ -25,19 +25,3 @@ export async function getUserSession({ email, password }) {
 export async function deleteNewUser() {
   return supabase.from("member").delete({ count: "exact" }).eq("id", process.env.CYPRESS_NEW_ID)
 }
-
-export async function giveUserAdminPrivileges() {
-  return supabase.rpc("set_claim", {
-    claim: "claims_admin",
-    uid: process.env.CYPRESS_OLD_ID,
-    value: true,
-  })
-}
-
-export async function removeUserAdminPrivileges() {
-  return supabase.rpc("set_claim", {
-    claim: "claims_admin",
-    uid: process.env.CYPRESS_OLD_ID,
-    value: false,
-  })
-}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -72,11 +72,3 @@ const executeTask = (taskName: string) => {
 Cypress.Commands.add("deleteNewUser", () => {
   return executeTask("deleteNewUser")
 })
-
-Cypress.Commands.add("giveUserAdminPrivileges", () => {
-  return executeTask("giveUserAdminPrivileges")
-})
-
-Cypress.Commands.add("removeUserAdminPrivileges", () => {
-  return executeTask("removeUserAdminPrivileges")
-})

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -30,16 +30,6 @@ declare global {
        *
        */
       deleteNewUser()
-
-      /**
-       * Custom command to give user admin privileges
-       */
-      giveUserAdminPrivileges()
-
-      /**
-       * Custom command to remove user admin privileges
-       */
-      removeUserAdminPrivileges()
     }
   }
 }

--- a/src/pages/repertoire/[song].tsx
+++ b/src/pages/repertoire/[song].tsx
@@ -15,6 +15,7 @@ import Spinner from "@/components/utils/spinner"
 import { useSupabaseClient, useUser } from "@supabase/auth-helpers-react"
 import { PostgrestError } from "@supabase/supabase-js"
 import SongPreviewImage from "@/components/images/song-preview-image"
+import { toast } from "react-toastify"
 
 interface SongProps {
   song: Song
@@ -53,7 +54,12 @@ const SongPage = (props: SongProps) => {
     divisionLength: number,
   ) => {
     if (exists && divisionLength == 1) {
-      setShowUpdateError("You're not allowed to remove yourself from this instrument.")
+      toast.error(
+        "Failed to remove you from the instrument. Please contact an administrator to remove you.",
+        {
+          toastId: "failed-to-remove-you",
+        },
+      )
     } else if (exists) {
       deleteDivision(supabase, divisionOperation).then(({ error }) => {
         handleDivisionOperation(error, "Failed to remove user from the instrument.")

--- a/src/pages/repertoire/[song].tsx
+++ b/src/pages/repertoire/[song].tsx
@@ -84,7 +84,7 @@ const SongPage = (props: SongProps) => {
   const moveToSuggestions = () => {
     setShowSpinner(true)
     moveSongToSuggestions(supabase, song.id)
-      .then(() => router.push("/repertoire"))
+      .then(() => router.push(`/suggestions/${song.id}`))
       .catch(() => setShowConversionError(true))
       .finally(() => setShowSpinner(false))
   }

--- a/src/pages/suggestions/[suggestion].tsx
+++ b/src/pages/suggestions/[suggestion].tsx
@@ -85,7 +85,7 @@ const SuggestionPage: FC<SuggestionPageProps> = ({
   const addToRepertoire = () => {
     setShowSpinner(true)
     createSongFromSuggestion(supabase, suggestion.id)
-      .then(() => router.push("/repertoire"))
+      .then(() => router.push(`/repertoire/${suggestion.id}`))
       .catch(() => setShowSongError(true))
       .finally(() => setShowSpinner(false))
   }

--- a/src/pages/suggestions/[suggestion].tsx
+++ b/src/pages/suggestions/[suggestion].tsx
@@ -82,10 +82,6 @@ const SuggestionPage: FC<SuggestionPageProps> = ({
     setInstrumentsInUpdate(instrumentsInUpdate.filter((item) => item.id !== songInstrument.id))
   }
 
-  const displayButton = (): boolean => {
-    return isAdmin && suggestion.song_instruments.filter((i) => i.division.length == 0).length == 0
-  }
-
   const addToRepertoire = () => {
     setShowSpinner(true)
     createSongFromSuggestion(supabase, suggestion.id)
@@ -174,7 +170,7 @@ const SuggestionPage: FC<SuggestionPageProps> = ({
               })}
             </div>
           </div>
-          {displayButton() && (
+          {isAdmin && (
             <div className={"m-8 flex justify-center"}>
               <button className={"btn toRepertoire"} onClick={() => addToRepertoire()}>
                 Move to repertoire
@@ -223,7 +219,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return {
       props: {
         suggestionFromNext: data,
-        isEditable: (data.author as { id: string }).id === session?.user.id,
+        isEditable:
+          (
+            data.author as {
+              id: string
+            }
+          ).id === session?.user.id || session?.user?.app_metadata.claims_admin === true,
       },
     }
   } catch {

--- a/src/pages/suggestions/[suggestion].tsx
+++ b/src/pages/suggestions/[suggestion].tsx
@@ -172,7 +172,11 @@ const SuggestionPage: FC<SuggestionPageProps> = ({
           </div>
           {isAdmin && (
             <div className={"m-8 flex justify-center"}>
-              <button className={"btn toRepertoire"} onClick={() => addToRepertoire()}>
+              <button
+                className={"btn toRepertoire"}
+                onClick={() => addToRepertoire()}
+                data-cy={"move-to-repertoire"}
+              >
                 Move to repertoire
               </button>
             </div>

--- a/src/pages/suggestions/edit/[suggestion].tsx
+++ b/src/pages/suggestions/edit/[suggestion].tsx
@@ -43,8 +43,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const { data } = await getSuggestion(supabase, params?.suggestion as string)
     if (data == null) return { notFound: true }
 
-    // If the user does not match with the author of the suggestion
-    if (session?.user.id !== data?.author.id)
+    // If the user does not match with the author of the suggestion and is not an admin, redirect to 403
+    if (session?.user.id !== data?.author.id && session?.user?.app_metadata.claims_admin !== true)
       return {
         redirect: {
           destination: "/403",

--- a/supabase/migrations/20231012161413_rls_delete_suggestion_admin.sql
+++ b/supabase/migrations/20231012161413_rls_delete_suggestion_admin.sql
@@ -4,6 +4,3 @@ as permissive
 for delete
 to authenticated
 using (is_claims_admin());
-
-
-

--- a/supabase/migrations/20231012182558_update_song_admin.sql
+++ b/supabase/migrations/20231012182558_update_song_admin.sql
@@ -1,0 +1,13 @@
+create policy "Enable update access for admins"
+on "public"."song"
+as permissive
+for update
+to authenticated
+using (is_claims_admin());
+
+create policy "Enable update access for admins"
+on "public"."song_instrument"
+as permissive
+for update
+to authenticated
+using (is_claims_admin());

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -36,6 +36,7 @@ INSERT INTO "public"."member" ("display_name", "id") VALUES ('Feryll', '1ce835c1
 
 -- Make 'old' user an admin
 SELECT set_claim('4ec7af50-3ced-45a9-9c1c-0e1038404778', 'claims_admin', 'true');
+SELECT set_claim('1ce835c1-a708-4e73-a808-334e982dfe3d', 'claims_admin', 'true');
 
 -- Create instruments
 INSERT INTO "public"."instrument" ("id", "instrument_name", "image_source") VALUES ('edc0bc16-b99f-436c-af63-3f9cd838c986', 'Vocals', 'micro');


### PR DESCRIPTION
* Closes #475 
* Also made 'Feryll' account in seed admin
* Removed tests for not admin account, could maybe be implemented in the future (#476)
* Error for removing when last musician in repertoire is now shown in toast