### PR TITLE
Fix word overflow of motivation on song card

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,12 @@ module.exports = withPWA({
         port: "",
         pathname: `/${process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME}/**`,
       },
+      {
+        protocol: "https",
+        hostname: `i.scdn.co`,
+        port: "",
+        pathname: `/image/**`,
+      },
     ],
   },
 })

--- a/src/components/images/song-image.tsx
+++ b/src/components/images/song-image.tsx
@@ -1,5 +1,6 @@
 import { MusicalNoteIcon } from "@heroicons/react/24/solid"
 import React from "react"
+import Image from "next/image"
 
 export interface SongImageProps {
   url: string | null
@@ -9,7 +10,7 @@ const SongImage = ({ url }: SongImageProps) => {
   return (
     <>
       {url ? (
-        <img src={url} height={64} width={64} alt={`song image`} className={"my-auto rounded-md"} />
+        <Image src={url} height={64} width={64} alt={`Song Image`} />
       ) : (
         <div className={"my-auto flex"}>
           <MusicalNoteIcon

--- a/src/components/suggestion/suggestion-card.tsx
+++ b/src/components/suggestion/suggestion-card.tsx
@@ -21,7 +21,12 @@ const SuggestionCard = ({ song, router, setShowSpinner }: SongCardProps) => {
         <span className={"pl-3"}>
           <p className={"line-clamp-1 font-bold"}>{song.title}</p>
           <p className={"line-clamp-1"}>{song.artist?.join(", ")}</p>
-          <p className={"line-clamp-3 h-12 text-sm font-medium leading-4 text-gray-400"}>
+          {/*The max width is the width of the card minus the width of the image and padding */}
+          <p
+            className={
+              "max-w-[calc(22rem-64px-calc(0.75rem*3))] line-clamp-3 h-12 text-sm font-medium leading-4 text-gray-400"
+            }
+          >
             {song.motivation}
           </p>
         </span>


### PR DESCRIPTION
Fixed it by setting a max width for it. Also changed img to Image.
Also put the Spotify image source as allowed remote source for images.

* Closes #536 

Before: 
![image](https://github.com/ASVGay/the-rhapsodies/assets/54884540/36bfec61-0fc0-4db2-970e-29449e1c7a76)

After:
![image](https://github.com/ASVGay/the-rhapsodies/assets/54884540/a2c4f6d3-b771-479a-b08e-81547d9edb2d)
